### PR TITLE
feat!: Remove Z correction register

### DIFF
--- a/pytket-mbqc-py/pytket_mbqc_py/graph_circuit.py
+++ b/pytket-mbqc-py/pytket_mbqc_py/graph_circuit.py
@@ -309,7 +309,8 @@ class GraphCircuit(QubitManager):
         :param vertex: Vertex to be corrected.
         """
         self.add_classicalexpbox_bit(
-            expression=self.qubit_meas_reg[self.vertex_qubit[vertex]][0] ^ self._get_z_correction_expression(vertex=vertex),
+            expression=self.qubit_meas_reg[self.vertex_qubit[vertex]][0]
+            ^ self._get_z_correction_expression(vertex=vertex),
             target=[self.qubit_meas_reg[self.vertex_qubit[vertex]][0]],
         )
 


### PR DESCRIPTION
In particular it is not necessary as Z corrections can be calculated from X corrections on neighbours.